### PR TITLE
Fix `action is not a function` error

### DIFF
--- a/src/SnotifyService.js
+++ b/src/SnotifyService.js
@@ -280,7 +280,7 @@ export default new Vue({
         this.$emit('toastChanged', latestToast)
       };
       this.$on(SnotifyAction.mounted, (passedToast) => {
-        if (passedToast.id === id) {
+        if (passedToast.id === id && action) {
           action().then((data) => {
             updateToast(SnotifyType.SUCCESS, data)
           }).catch((data) => {


### PR DESCRIPTION
In the `async` toast the `action` is used to complete the asynchronous task to success or error. I'm using Vuex reactivity to close the `async` toast and am not setting an `action`. If `action` is null then an error is reported in the console.

This small change will fix this issue.