### PR TITLE
fix type of plugin reference in vue for intellisense

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ const Plugin = {
 
 declare module 'vue/types/vue' {
   interface Vue {
-    $snotify: SnotifyService | any;
+    $snotify: SnotifyService;
   }
 }
 


### PR DESCRIPTION
Fixed type of plugin reference in vue prototype to SnotifyService.
Intellisense in Visual Studio Code is not working when Type is any.