### PR TITLE
changed sass variables to use !default which enables overriding colors

### DIFF
--- a/src/styles/_shared/snotify.scss
+++ b/src/styles/_shared/snotify.scss
@@ -1,4 +1,4 @@
-$snotify-backdrop-color: #000;
+$snotify-backdrop-color: #000 !default;
 
 .snotify {
   display: block;

--- a/src/styles/dark/icon.scss
+++ b/src/styles/dark/icon.scss
@@ -1,8 +1,8 @@
-$snotify-success: #4caf50;
-$snotify-info: #1e88e5;
-$snotify-warning: #ff9800;
-$snotify-error: #f44336;
-$snotify-async: $snotify-info;
+$snotify-success: #4caf50 !default;
+$snotify-info: #1e88e5 !default;
+$snotify-warning: #ff9800 !default;
+$snotify-error: #f44336 !default;
+$snotify-async: $snotify-info !default;
 
 $snotify-icons: -generate-icons(
   (
@@ -12,7 +12,7 @@ $snotify-icons: -generate-icons(
     success: $snotify-success,
     async: $snotify-async
   )
-);
+) !default;
 
 .snotify-icon {
   position: absolute;

--- a/src/styles/dark/toast.scss
+++ b/src/styles/dark/toast.scss
@@ -1,7 +1,7 @@
-$snotify-toast-bg: rgba(0, 0, 0, .9);
-$snotify-toast-color: #fff;
-$snotify-toast-progressBar: #000;
-$snotify-toast-progressBarPercentage: #4c4c4c;
+$snotify-toast-bg: rgba(0, 0, 0, .9) !default;
+$snotify-toast-color: #fff !default;
+$snotify-toast-progressBar: #000 !default;
+$snotify-toast-progressBarPercentage: #4c4c4c !default;
 
 .snotifyToast {
   display: block;

--- a/src/styles/material/icon.scss
+++ b/src/styles/material/icon.scss
@@ -1,8 +1,8 @@
-$snotify-success: #c8e6c9;
-$snotify-info: #bbdefb;
-$snotify-warning: #ffccbc;
-$snotify-error: #ffcdd2;
-$snotify-async: $snotify-info;
+$snotify-success: #c8e6c9 !default;
+$snotify-info: #bbdefb !default;
+$snotify-warning: #ffccbc !default;
+$snotify-error: #ffcdd2 !default;
+$snotify-async: $snotify-info !default;
 
 $snotify-icons: -generate-icons(
   (
@@ -12,7 +12,7 @@ $snotify-icons: -generate-icons(
     success: $snotify-success,
     async: $snotify-async
   )
-);
+) !default;
 
 .snotify-icon {
   position: absolute;

--- a/src/styles/material/toast.scss
+++ b/src/styles/material/toast.scss
@@ -1,40 +1,40 @@
-$snotify-simple-bg: #fff;
-$snotify-simple-color: #000;
-$snotify-simple-progressBar: #c7c7c7;
-$snotify-simple-progressBarPercentage: #4c4c4c;
+$snotify-simple-bg: #fff !default;
+$snotify-simple-color: #000 !default;
+$snotify-simple-progressBar: #c7c7c7 !default;
+$snotify-simple-progressBarPercentage: #4c4c4c !default;
 
-$snotify-success-bg: #4caf50;
-$snotify-success-color: #c8e6c9;
-$snotify-success-progressBar: #388e3c;
-$snotify-success-progressBarPercentage: #81c784;
+$snotify-success-bg: #4caf50 !default;
+$snotify-success-color: #c8e6c9 !default;
+$snotify-success-progressBar: #388e3c !default;
+$snotify-success-progressBarPercentage: #81c784 !default;
 
-$snotify-info-bg: #1e88e5;
-$snotify-info-color: #e3f2fd;
-$snotify-info-progressBar: #1565c0;
-$snotify-info-progressBarPercentage: #64b5f6;
+$snotify-info-bg: #1e88e5 !default;
+$snotify-info-color: #e3f2fd !default;
+$snotify-info-progressBar: #1565c0 !default;
+$snotify-info-progressBarPercentage: #64b5f6 !default;
 
-$snotify-warning-bg: #ff9800;
-$snotify-warning-color: #fff3e0;
-$snotify-warning-progressBar: #ef6c00;
-$snotify-warning-progressBarPercentage: #ffcc80;
+$snotify-warning-bg: #ff9800 !default;
+$snotify-warning-color: #fff3e0 !default;
+$snotify-warning-progressBar: #ef6c00 !default;
+$snotify-warning-progressBarPercentage: #ffcc80 !default;
 
-$snotify-error-bg: #f44336;
-$snotify-error-color: #ffebee;
-$snotify-error-progressBar: #c62828;
-$snotify-error-progressBarPercentage: #ef9a9a;
+$snotify-error-bg: #f44336 !default;
+$snotify-error-color: #ffebee !default;
+$snotify-error-progressBar: #c62828 !default;
+$snotify-error-progressBarPercentage: #ef9a9a !default;
 
-$snotify-async-bg: $snotify-info-bg;
-$snotify-async-color: $snotify-info-color;
-$snotify-async-progressBar: $snotify-info-progressBar;
-$snotify-async-progressBarPercentage: $snotify-info-progressBarPercentage;
+$snotify-async-bg: $snotify-info-bg !default;
+$snotify-async-color: $snotify-info-color !default;
+$snotify-async-progressBar: $snotify-info-progressBar !default;
+$snotify-async-progressBarPercentage: $snotify-info-progressBarPercentage !default;
 
-$snotify-confirm-bg: #009688;
-$snotify-confirm-color: #e0f2f1;
-$snotify-confirm-progressBar: #4db6ac;
-$snotify-confirm-progressBarPercentage: #80cbc4;
+$snotify-confirm-bg: #009688 !default;
+$snotify-confirm-color: #e0f2f1 !default;
+$snotify-confirm-progressBar: #4db6ac !default;
+$snotify-confirm-progressBarPercentage: #80cbc4 !default;
 
-$snotify-prompt-bg: #009688;
-$snotify-prompt-color: #e0f2f1;
+$snotify-prompt-bg: #009688 !default;
+$snotify-prompt-color: #e0f2f1 !default;
 
 .snotifyToast {
   display: block;

--- a/src/styles/simple/icon.scss
+++ b/src/styles/simple/icon.scss
@@ -1,8 +1,8 @@
-$snotify-success: $snotify-success-border-color;
-$snotify-info: $snotify-info-border-color;
-$snotify-warning: $snotify-warning-border-color;
-$snotify-error: $snotify-error-border-color;
-$snotify-async: $snotify-async-border-color;
+$snotify-success: $snotify-success-border-color !default;
+$snotify-info: $snotify-info-border-color !default;
+$snotify-warning: $snotify-warning-border-color !default;
+$snotify-error: $snotify-error-border-color !default;
+$snotify-async: $snotify-async-border-color !default;
 
 $snotify-icons: -generate-icons(
   (
@@ -12,7 +12,7 @@ $snotify-icons: -generate-icons(
     success: $snotify-success,
     async: $snotify-async
   )
-);
+) !default;
 
 .snotify-icon {
   position: absolute;

--- a/src/styles/simple/toast.scss
+++ b/src/styles/simple/toast.scss
@@ -1,17 +1,17 @@
-$snotify-toast-bg: #fff;
-$snotify-toast-color: #000;
-$snotify-toast-progressBar: #c7c7c7;
-$snotify-toast-progressBarPercentage: #4c4c4c;
+$snotify-toast-bg: #fff !default;
+$snotify-toast-color: #000 !default;
+$snotify-toast-progressBar: #c7c7c7 !default;
+$snotify-toast-progressBarPercentage: #4c4c4c !default;
 
-$snotify-border-width: 4px;
-$snotify-simple-border-color: #000;
-$snotify-success-border-color: #4caf50;
-$snotify-info-border-color: #1e88e5;
-$snotify-warning-border-color: #ff9800;
-$snotify-error-border-color: #f44336;
-$snotify-async-border-color: $snotify-info-border-color;
-$snotify-confirm-border-color: #009688;
-$snotify-prompt-border-color: $snotify-confirm-border-color;
+$snotify-border-width: 4px !default;
+$snotify-simple-border-color: #000 !default;
+$snotify-success-border-color: #4caf50 !default;
+$snotify-info-border-color: #1e88e5 !default;
+$snotify-warning-border-color: #ff9800 !default;
+$snotify-error-border-color: #f44336 !default;
+$snotify-async-border-color: $snotify-info-border-color !default;
+$snotify-confirm-border-color: #009688 !default;
+$snotify-prompt-border-color: $snotify-confirm-border-color !default;
 
 .snotifyToast {
   display: block;


### PR DESCRIPTION
Changed sass variables in the themes to use !default.
This enables overriding colors by variables instead of copy/create an own theme.

For Example:
$snotify-success: $color-white;
$snotify-success-bg: $color-green;
$snotify-success-color: $color-white;
@import "~vue-snotify/styles/material";