### PR TITLE
Add Vue.js slot support

### DIFF
--- a/src/components/Snotify/snotify.html
+++ b/src/components/Snotify/snotify.html
@@ -2,6 +2,27 @@
   <div class="snotify-backdrop" v-if="backdrop >= 0" :style="{opacity: backdrop}"></div>
   <div v-for="(position, index) in notifications" class="snotify" :class="'snotify-' + index">
     <toast v-for="toast in notifications[index].slice(blockSize_a, blockSize_b)" :toastData="toast" :key="toast.id" @stateChanged="stateChanged">
+      <template slot="progressBar" slot-scope="{state}">
+        <slot name="progressBar" :toast="toast" :state="state"></slot>
+      </template>
+      <template slot="inner">
+        <slot name="inner" :toast="toast"></slot>
+      </template>
+      <template slot="title">
+        <slot name="title" :toast="toast"></slot>
+      </template>
+      <template slot="body">
+        <slot name="body" :toast="toast"></slot>
+      </template>
+      <template slot="prompt">
+        <slot name="prompt" :toast="toast"></slot>
+      </template>
+      <template slot="icon">
+        <slot name="icon" :toast="toast"></slot>
+      </template>
+      <template slot="buttons">
+        <slot name="buttons" :toast="toast"></slot>
+      </template>
     </toast>
   </div>
 </div>

--- a/src/components/Snotify/snotify.html
+++ b/src/components/Snotify/snotify.html
@@ -1,28 +1,9 @@
 <div>
   <div class="snotify-backdrop" v-if="backdrop >= 0" :style="{opacity: backdrop}"></div>
   <div v-for="(position, index) in notifications" class="snotify" :class="'snotify-' + index">
-    <toast v-for="toast in notifications[index].slice(blockSize_a, blockSize_b)" :toastData="toast" :key="toast.id" @stateChanged="stateChanged">
-      <template slot="progressBar" slot-scope="{state}">
-        <slot name="progressBar" :toast="toast" :state="state"></slot>
-      </template>
-      <template slot="inner">
-        <slot name="inner" :toast="toast"></slot>
-      </template>
-      <template slot="title">
-        <slot name="title" :toast="toast"></slot>
-      </template>
-      <template slot="body">
-        <slot name="body" :toast="toast"></slot>
-      </template>
-      <template slot="prompt">
-        <slot name="prompt" :toast="toast"></slot>
-      </template>
-      <template slot="icon">
-        <slot name="icon" :toast="toast"></slot>
-      </template>
-      <template slot="buttons">
-        <slot name="buttons" :toast="toast"></slot>
-      </template>
-    </toast>
+    <slot name="toast" v-for="toast in notifications[index].slice(blockSize_a, blockSize_b)" :snotify="{stateChanged: stateChanged, toast:toast}">
+      <toast :toastData="toast" :key="toast.id" @stateChanged="stateChanged">
+      </toast>
+    </slot>
   </div>
 </div>

--- a/src/components/SnotifyToast/toast.html
+++ b/src/components/SnotifyToast/toast.html
@@ -10,7 +10,7 @@
             transition: toast.config.animation.time + 'ms'
           }"
   @click="onClick" @mouseenter="onMouseEnter" @mouseleave="onMouseLeave" @animationend="onExitTransitionEnd">
-  <slot name="progressBar" v-if="toast.config.showProgressBar && toast.config.timeout > 0" :toast="toast" :state="state">
+  <slot name="progressBar" v-if="toast.config.showProgressBar && toast.config.timeout > 0" :state="state">
     <div class="snotifyToast__progressBar">
       <span class="snotifyToast__progressBar__percentage" :style="{'width': (state.progress * 100) + '%'}"></span>
     </div>

--- a/src/components/SnotifyToast/toast.html
+++ b/src/components/SnotifyToast/toast.html
@@ -27,7 +27,7 @@
         <snotify-prompt :toast="toast">
         </snotify-prompt>
       </slot>
-      <slot name="icon">
+      <slot name="icon" :toast="toast">
         <div v-if="!toast.config.icon" :class="['snotify-icon', 'snotify-icon--' + toast.config.type]"></div>
         <div v-else>
           <img class="snotify-icon" :src='toast.config.icon'/>

--- a/src/components/SnotifyToast/toast.html
+++ b/src/components/SnotifyToast/toast.html
@@ -10,19 +10,33 @@
             transition: toast.config.animation.time + 'ms'
           }"
   @click="onClick" @mouseenter="onMouseEnter" @mouseleave="onMouseLeave" @animationend="onExitTransitionEnd">
-  <div class="snotifyToast__progressBar" v-if="toast.config.showProgressBar && toast.config.timeout > 0">
-    <span class="snotifyToast__progressBar__percentage" :style="{'width': (state.progress * 100) + '%'}"></span>
-  </div>
-  <div class="snotifyToast__inner" v-if="!toast.config.html">
-    <div class="snotifyToast__title" v-if="toast.title">{{toast.title | truncate(toast.config.titleMaxLength)}}</div>
-    <div class="snotifyToast__body" v-if="toast.body">{{toast.body | truncate(toast.config.bodyMaxLength)}}</div>
-    <snotify-prompt v-if="toast.config.type === state.promptType" :toast="toast">
-    </snotify-prompt>
-    <div v-if="!toast.config.icon" :class="['snotify-icon', 'snotify-icon--' + toast.config.type]"></div>
-    <div v-else>
-      <img class="snotify-icon" :src='toast.config.icon'/>
+  <slot name="progressBar" v-if="toast.config.showProgressBar && toast.config.timeout > 0" :toast="toast" :state="state">
+    <div class="snotifyToast__progressBar">
+      <span class="snotifyToast__progressBar__percentage" :style="{'width': (state.progress * 100) + '%'}"></span>
     </div>
+  </slot>
+  <div class="snotifyToast__inner" v-if="!toast.config.html">
+    <slot name="inner" :toast="toast">
+      <slot name="title" :toast="toast" v-if="toast.title">
+        <div class="snotifyToast__title">{{toast.title | truncate(toast.config.titleMaxLength)}}</div>
+      </slot>
+      <slot name="body" :toast="toast" v-if="toast.body">
+        <div class="snotifyToast__body">{{toast.body | truncate(toast.config.bodyMaxLength)}}</div>
+      </slot>
+      <slot name="prompt" :toast="toast" v-if="toast.config.type === state.promptType">
+        <snotify-prompt :toast="toast">
+        </snotify-prompt>
+      </slot>
+      <slot name="icon">
+        <div v-if="!toast.config.icon" :class="['snotify-icon', 'snotify-icon--' + toast.config.type]"></div>
+        <div v-else>
+          <img class="snotify-icon" :src='toast.config.icon'/>
+        </div>
+      </slot>
+    </slot>
   </div>
   <div class="snotifyToast__inner" v-html="toast.config.html" v-else></div>
-  <snotify-button v-if="toast.config.buttons" :toast="toast"></snotify-button>
+  <slot name="buttons" :toast="toast" v-if="toast.config.buttons">
+    <snotify-button v-if="toast.config.buttons" :toast="toast"></snotify-button>
+  </slot>
 </div>


### PR DESCRIPTION
Adding slots allows certain HTML blocks to be overwritten.

**Usage without slots**
```vue
<vue-snotify :class="style"></vue-snotify>
```

**Available slots**

- progressBar
- inner
- title
- body
- prompt
- icon
- buttons

**Usage to override icon**
```vue
<vue-snotify :class="style">
  <template slot="toast" slot-scope="{snotify}">
    <toast :toastData="snotify.toast" :key="snotify.toast.id" @stateChanged="snotify.stateChanged">
      <div class="icon" slot="icon" slot-scope="{toast}">
        <span class="w-48 rounded accent">
          <i class="material-icons" v-if="toast.config.type === 'success'">&#xE24B;</i>
        </span>
      </div>
    </toast>
  </template>
</vue-snotify>
```

**Usage to allow HTML in body or title**
```vue
<vue-snotify :class="style">
  <template slot="toast" slot-scope="{snotify}">
    <toast :toastData="snotify.toast" :key="snotify.toast.id" @stateChanged="snotify.stateChanged">
      <template slot="title" slot-scope="{toast}">
        <div class="snotifyToast__title" v-html="toast.title"></div>
      </template>
      <template slot="body" slot-scope="{toast}">
        <div class="snotifyToast__body" v-html="toast.body"></div>
      </template>
    </toast>
  </template>
</vue-snotify>
```