### PR TITLE
proposal: add inital value for input of prompt toasts

### DIFF
--- a/docs/api/options.md
+++ b/docs/api/options.md
@@ -79,6 +79,12 @@ Vue.use(Snotify, {
 - default: `"Enter answer here..."`
   > Placeholder for Prompt toast
   
+### initialValue
+
+- type: `string`
+- default: `""`
+  > Inital value for Prompt toast
+  
 ### titleMaxLength
 
 - type: `number`

--- a/example/src/App/app.ts
+++ b/example/src/App/app.ts
@@ -146,10 +146,11 @@ export class App extends Vue {
         {text: 'Yes', action: (toast) => console.log('Said Yes: ' + toast.value) },
         {text: 'No', action: (toast) => { console.log('Said No: ' + toast.value); this.$snotify.remove(toast.id); }},
       ],
-      placeholder: 'Enter "ng-snotify" to validate this input' // Max-length = 40
+      placeholder: 'Enter "vue-snotify" to validate this input', // Max-length = 40
+      initialValue: 'ng-snotify'
     }).on('input', (toast) => {
       console.log(toast.value);
-      toast.valid = !!toast.value.match('ng-snotify');
+      toast.valid = !!toast.value.match('vue-snotify');
     });
 
 

--- a/example/test/unit/specs/Prompt.spec.ts
+++ b/example/test/unit/specs/Prompt.spec.ts
@@ -80,6 +80,17 @@ describe('Prompt Toast', () => {
       });
     });
   });
+  
+  it('should set initial value', (done) => {
+    const toast = vm.$snotify.prompt('test', 'test2', {
+      initialValue: 'Hello'
+    });
+    vm.$nextTick(() => {
+      const node: HTMLInputElement = vm.$el.querySelector('.snotify.snotify-rightBottom .snotifyToast.snotify-prompt input');
+      expect(node.value).toEqual('Hello');
+      done();
+    });
+  });
 });
 
 

--- a/src/components/SnotifyPrompt.vue
+++ b/src/components/SnotifyPrompt.vue
@@ -1,6 +1,7 @@
 <template>
 <span class="snotifyToast__input" :class="{'snotifyToast__input--filled': isPromptFocused}">
     <input @input="valueChanged"
+           :value="toast.value"
            class="snotifyToast__input__field" type="text"
            :id="toast.id"
            @focus="isPromptFocused = true"

--- a/src/components/toast.model.ts
+++ b/src/components/toast.model.ts
@@ -37,7 +37,7 @@ export class SnotifyToast {
                public body: string,
                public config: SnotifyToastConfig) {
     if (this.config.type === SnotifyStyle.prompt) {
-      this.value = '';
+      this.value = this.config.initialValue;
     }
     this.on('hidden', () => {
       this._eventsHolder.forEach((o) => {

--- a/src/interfaces/SnotifyToastConfig.interface.ts
+++ b/src/interfaces/SnotifyToastConfig.interface.ts
@@ -57,6 +57,12 @@ export interface SnotifyToastConfig {
    */
   placeholder?: string;
   /**
+   * Initial input value for Prompt toast
+   * @type {string}
+   * @default ''
+   */
+  initialValue?: string;
+  /**
    * Toast title maximum length
    * @type {number}
    * @default 16

--- a/src/toastDefaults.ts
+++ b/src/toastDefaults.ts
@@ -35,6 +35,7 @@ export const ToastDefaults = {
         {text: 'Cancel', action: null, bold: false},
       ],
       placeholder: 'Enter answer here...',
+      initialValue: '',
       type: SnotifyStyle.prompt,
     },
     [SnotifyStyle.confirm]: {


### PR DESCRIPTION
proposing the possibility to add an inital value for prompt toasts. this enhances user experience when using prompt toasts for tasks like renaming things.