### PR TITLE
Small width fix to keep notifications inside narrow screens

### DIFF
--- a/src/styles/_shared/snotify.scss
+++ b/src/styles/_shared/snotify.scss
@@ -6,6 +6,7 @@ $snotify-offset: 10px !default;
   display: block;
   position: fixed;
   width: $snotify-width;
+  max-width: calc(100% - #{$snotify-offset} * 2);
   z-index: 9999;
   box-sizing: border-box;
   pointer-events: none;


### PR DESCRIPTION
On small screens, specially if you increase `$snotify-width`, toast messages get outside of the screen.
This fix should give them a max width of 100% of the screen minus the left and right offsets.

Before
![image](https://user-images.githubusercontent.com/4517370/87156900-b638ba80-c2bd-11ea-8989-d354b8ba26c4.png)

After
![image](https://user-images.githubusercontent.com/4517370/87156914-b9cc4180-c2bd-11ea-88e8-beb78e092071.png)
